### PR TITLE
Fix non-mesh shader GPU path on 1.20.1

### DIFF
--- a/src/main/java/me/cortex/voxy/client/AccessFrustumIntersection.java
+++ b/src/main/java/me/cortex/voxy/client/AccessFrustumIntersection.java
@@ -1,0 +1,22 @@
+package me.cortex.voxy.client;
+import org.joml.FrustumIntersection;
+import org.joml.Vector4f;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+
+public class AccessFrustumIntersection {
+    private static final VarHandle planesHandle;
+    static {
+        try {
+            final Field planesField = FrustumIntersection.class.getDeclaredField("planes");
+            planesField.setAccessible(true);
+            planesHandle = MethodHandles.privateLookupIn(FrustumIntersection.class, MethodHandles.lookup()).unreflectVarHandle(planesField);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    public static Vector4f[] getPlanes(FrustumIntersection fi) {
+        return (Vector4f[]) planesHandle.get(fi);
+    }
+}

--- a/src/main/java/me/cortex/voxy/client/core/model/ModelTextureBakery.java
+++ b/src/main/java/me/cortex/voxy/client/core/model/ModelTextureBakery.java
@@ -208,7 +208,11 @@ public class ModelTextureBakery {
 
 
         if (blockEntityModel != null && !renderFluid) {
-            blockEntityModel.renderOut();
+            try {
+                blockEntityModel.renderOut();
+            } catch (IllegalStateException e) {
+                System.err.println("Got empty buffer builder! for model " + blockEntityModel);
+            }
         }
 
         vc.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR_TEXTURE);

--- a/src/main/java/me/cortex/voxy/client/core/rendering/Gl46FarWorldRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/Gl46FarWorldRenderer.java
@@ -1,10 +1,10 @@
 package me.cortex.voxy.client.core.rendering;
 
+import me.cortex.voxy.client.AccessFrustumIntersection;
 import me.cortex.voxy.client.core.gl.GlBuffer;
 import me.cortex.voxy.client.core.gl.shader.Shader;
 import me.cortex.voxy.client.core.gl.shader.ShaderType;
 import me.cortex.voxy.client.core.rendering.util.UploadStream;
-import me.cortex.voxy.client.mixin.joml.AccessFrustumIntersection;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.util.math.MatrixStack;
@@ -96,7 +96,7 @@ public class Gl46FarWorldRenderer extends AbstractFarWorldRenderer<Gl46Viewport>
         MemoryUtil.memPutInt(ptr, this.sy); ptr += 4;
         MemoryUtil.memPutInt(ptr, this.sz); ptr += 4;
         MemoryUtil.memPutInt(ptr, this.geometry.getSectionCount()); ptr += 4;
-        var planes = ((AccessFrustumIntersection)this.frustum).getPlanes();
+        var planes = AccessFrustumIntersection.getPlanes(this.frustum);
         for (var plane : planes) {
             plane.getToAddress(ptr); ptr += 4*4;
         }


### PR DESCRIPTION
Backport of https://github.com/ferriarnus/mixy/commit/fea3f87301aca6b91c70fe5b01a599e61ab17f01 to the 1.20.1 branch.